### PR TITLE
Refactored log.

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -11,12 +11,12 @@ function Log(message, color) {
 		cyan: 	 '\x1b[36m',
 		white:	 '\x1b[37m'
 	};
-	// This allows uss to print objects to a limit of a single depth
-	let arg_arr = [...arguments]
-		  .slice()
+	// This allows us to print objects to a limit of a single depth
+	const arg_arr = Array
+		  .from(arguments)
 		  .map((index) => {
 			if (typeof index === 'object') index = (
-				`\n{${
+				`{\n{${
 				Object.entries(index).map((sub_index) => {
 					return '\n\t' + sub_index[0] + ': '+ sub_index[1]
 					})
@@ -25,7 +25,7 @@ function Log(message, color) {
 
 		return index;
 	});
-	let possible_color = arg_arr.pop(); // TODO || Possible color should not be popped and allowed to stay in arg_arr
+	const possible_color = arg_arr.pop(); // TODO || Possible color should not be popped and allowed to stay in arg_arr
 	// I am adding another parameter to suit this as a required value
 	console.log((colors[possible_color]||possible_color), ...arg_arr, colors['clear']);
 };
@@ -33,6 +33,6 @@ function Log(message, color) {
 
 /**
  *	Single depth object inspection prevents recursion
-*	Log('stuff here', [1,2,3,4,5], new Set(), {body: 'asdasdasd', scripts: { init: { asd:'asdasd' } } }, 'and more stuff here', 'green');
+ *	Log('stuff here', [1,2,3,4,5], new Set(), {body: 'asdasdasd', scripts: { init: { asd:'asdasd' } } }, 'and more stuff here', 'green');
 */
 module.exports = Log;


### PR DESCRIPTION
- [x] Removed redundant shallow copy from `arg_arr`. Array spreading already provides a shallow copy of `arguments` the `.slice` was redundant, `Array.from` provides slight speed improvements and, subjectively, is easier to read.
- [x] Variable declarations `let` -> `const`. Since we're returning an array with `arg_arr` there's almost no reason not to, we shouldn't be reassigning `arg_arr` in this function probably.. `possible_color` is debatable, but does provide consistency.
- [x] fixed spelling mistake `uss` -> `us`.

Further refactorings of this should probably make it a decorator on the console.log function and attempt to intercept any calls made to console.log as well, preferably throwing a warning error or something of the sort if the intent is to **take over the wor**- console.

Providing some kind of memoization via `Set`, `WeakMap`, or monad could prevent recursive calls allowing deep object inspection.