### PR TITLE
 Remove body parser

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,7 +10,6 @@
  */
 const express  = require('express'); // I'm okay with this dependancy due to familiarity, I am certainly leaning on it. Popular, I should consider contribution or personal rewrite
 const helmet   = require('helmet'); // I'm okay with this dependancy for now, reevaluate with time
-const bodyParser = require('body-parser'); // I'm okay with this dependancy for now, reevaluate with time
 const fs       = require('fs'); // This is exposed in two places, here, and inside of the monolith as a function pointer in the constructor
 
 const Monolith = require('./src/monolith.js'); // Compose the html, consolidate the assets, we need auto-detection on types, consider an upper abstraction that composes the monoliths and applys the rituals
@@ -67,7 +66,7 @@ const theUninitiated = new Ritual(
 		{
 			path: '/', 	page: VirtualMonolith, // If we instead pass VirtualMonolith.payload we will create unique instances between each session.
 			post: [
-				bodyParser.urlencoded({extended: false}),
+				express.urlencoded({extended: false}),
 				(req, res, next) => {
 
 					function isAlpha(str) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "homepage": "https://github.com/etisdew/AlterJS#readme",
   "dependencies": {
     "bcrypt": "^3.0.3",
-    "body-parser": "^1.18.3",
     "express": "^4.16.4",
     "helmet": "^3.15.0"
   }

--- a/src/rituals/sound.js
+++ b/src/rituals/sound.js
@@ -1,5 +1,5 @@
 const mongoose   = require('mongoose');
-const bodyParser = require('body-parser');
+const express = require('express');
 const bcrypt     = require('bcrypt');
 
 const Log	 = require('../log.js');
@@ -23,7 +23,7 @@ const User = mongoose.model('user', UserSchema);
 module.exports = {
 	path: '/',
 	post: [
-		bodyParser.urlencoded({
+		express.urlencoded({
 			extended: false
 		}),
 		(req, res, next) => {


### PR DESCRIPTION
As of express 4.16.0 body-parser has been reintegrated into express. [changelog link](https://expressjs.com/en/changelog/4x.html#4.16.0). Unless you're needed an esoteric body-parser function there's no reason to have it as a dependency.